### PR TITLE
Allow non-id-linked labels

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ module.exports = {
 
     // allow non-ID-linked <label>s to accomodate those containing linked <input>s
     'jsx-a11y/label-has-for': 0,
+    'jsx-a11y/label-has-associated-control': [2, {assert: 'some'}],
 
     // allow supposedly-confusing arrows
     'no-confusing-arrow': 0,


### PR DESCRIPTION
We already allow non-ID-linked `<label>`s, but we do so by [disabling a deprecated rule](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md#deprecated-label-has-for). We can either continue to allow it outright (including `<label>`s that do not contain an `<input>`) or we use the 'jsx-a11y/label-has-associated-control' rule to enforce that either a `<label>` wraps an `<input>` or is ID-linked.

Thoughts?

//cc @billyjanitsch 