### PR TITLE
Fix label-has-associated-control rule config

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = {
 
     // allow non-ID-linked <label>s to accomodate those containing linked <input>s
     'jsx-a11y/label-has-for': 0,
-    'jsx-a11y/label-has-associated-control': [2, {assert: 'some'}],
+    'jsx-a11y/label-has-associated-control': [2, {assert: 'either'}],
 
     // allow supposedly-confusing arrows
     'no-confusing-arrow': 0,


### PR DESCRIPTION
I didn't use the right word in #29 😬

https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/b800f40a2a69ad48015ae9226fbe879f946757ed/src/rules/label-has-associated-control.js#L28

//cc @billyjanitsch 