### PR TITLE
Add a separate configuration with TypeScript Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,24 @@ Add a script in **package.json** to [run the linter](http://eslint.org/docs/user
 }
 ```
 
+### TypeScript
+
+Have your **.eslintrc.yml** extend the TypeScript specific config:
+
+```yml
+extends: kensho/typescript
+```
+
+Make sure your **package.json** script has an `--ext` flag to include `.ts` and `.tsx` files:
+
+```json
+{
+  "scripts": {
+    "lint": "eslint src --ext ts,tsx"
+  }
+}
+```
+
 ## Caveat
 
 The eslint-plugin-X dependencies specified in [package.json](package.json) should actually be peer dependencies (see eslint/eslint#2518), and installed alongside eslint and this config. In practice, this is quite tedious, so we have instead specified them as dependencies and rely on npm@3's flattening to install them alongside the linter.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1738,6 +1738,15 @@
         }
       }
     },
+    "eslint-plugin-typescript": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-typescript/-/eslint-plugin-typescript-0.14.0.tgz",
+      "integrity": "sha512-2u1WnnDF2mkWWgU1lFQ2RjypUlmRoBEvQN02y9u+IL12mjWlkKFGEBnVsjs9Y8190bfPQCvWly1c2rYYUSOxWw==",
+      "optional": true,
+      "requires": {
+        "requireindex": "~1.1.0"
+      }
+    },
     "eslint-restricted-globals": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz",
@@ -4487,6 +4496,12 @@
           "dev": true
         }
       }
+    },
+    "requireindex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
+      "integrity": "sha1-5UBLgVV+91225JxacgBIk/4D4WI=",
+      "optional": true
     },
     "resolve": {
       "version": "1.8.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.1",
     "eslint-plugin-prettier": "^3.0.0",
-    "eslint-plugin-react": "^7.11.1"
+    "eslint-plugin-react": "^7.11.1",
+    "typescript-eslint-parser": "^21.0.1",
+    "eslint-plugin-typescript": "^0.14.0"
   },
   "devDependencies": {
     "ava": "1.0.0-beta.8",

--- a/typescript.js
+++ b/typescript.js
@@ -1,0 +1,18 @@
+module.exports = {
+  extends: ['kensho'],
+  plugins: ['typescript'],
+  parser: 'typescript-eslint-parser',
+  rules: {
+    // Prevent TypeScript-specific constructs from being erroneously flagged as unused
+    // https://github.com/bradzacher/eslint-plugin-typescript/blob/master/docs/rules/no-unused-vars.md
+    'typescript/no-unused-vars': 'error',
+  },
+  settings: {
+    'import/extensions': ['.js', '.ts'],
+    'import/resolver': {
+      'node': {
+        'extensions': ['.js', '.jsx', '.ts', '.tsx']
+      }
+    },
+  },
+}


### PR DESCRIPTION
Unfortunately even with Babel's TS plugin ESLint still runs into parse errors, so this adds a configuration which uses the `typescript-eslint-parser` parser.

It also adds:
* `eslint-plugin-typescript`: Used to mark type imports as used for `no-unused-vars`
* `.ts` and `.tsx` to `import/resolver.node.extensions` so `eslint-plugin-import` handles TS imports properly