### PR TITLE
Lint JSDoc comments

### DIFF
--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -47,6 +47,8 @@ Array [
 ]
 `;
 
+exports[`lints all fixtures: jsdoc.ts 1`] = `Array []`;
+
 exports[`lints all fixtures: prop-types.js 1`] = `
 Array [
   Object {

--- a/fixtures/jsdoc.ts
+++ b/fixtures/jsdoc.ts
@@ -1,0 +1,10 @@
+/**
+ * Adds two numbers.
+ *
+ * @param a The first number to add.
+ * @param b The second number to add.
+ * @returns The sum.
+ */
+function add(a: number, b: number): number {
+  return a + b
+}

--- a/fixtures/jsdoc.ts
+++ b/fixtures/jsdoc.ts
@@ -19,3 +19,8 @@ function subtract(a: number, b: number): number {
 function multiply(a: number, b: number): number {
   return a * b
 }
+
+/* a regular, non-jsdoc comment */
+function divide(a: number, b: number): number {
+  return a / b
+}

--- a/fixtures/jsdoc.ts
+++ b/fixtures/jsdoc.ts
@@ -8,3 +8,14 @@
 function add(a: number, b: number): number {
   return a + b
 }
+
+/**
+ * Subtracts two numbers.
+ */
+function subtract(a: number, b: number): number {
+  return a - b
+}
+
+function multiply(a: number, b: number): number {
+  return a * b
+}

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 module.exports = {
   extends: ['airbnb', 'airbnb/hooks', 'prettier', 'prettier/react'],
-  plugins: ['prettier'],
+  plugins: ['prettier', 'jsdoc'],
   parser: 'babel-eslint',
   env: {
     // allow browser globals
@@ -16,6 +16,21 @@ module.exports = {
 
     // require import groups to be ordered by specificity and separated by linebreaks
     'import/order': [2, {'newlines-between': 'always'}],
+
+    // require well-formatted JSDoc comments, when they exist
+    'jsdoc/check-alignment': 2,
+    'jsdoc/check-indentation': 2,
+    'jsdoc/check-param-names': 2,
+    'jsdoc/check-tag-names': 2,
+    'jsdoc/newline-after-description': 2,
+    'jsdoc/require-hyphen-before-param-description': [2, 'never'],
+    'jsdoc/require-description': 2,
+    'jsdoc/require-description-complete-sentence': 2,
+    'jsdoc/require-param': 2,
+    'jsdoc/require-param-description': 2,
+    'jsdoc/require-param-name': 2,
+    'jsdoc/require-returns': 2,
+    'jsdoc/require-returns-description': 2,
 
     // allow non-ID-linked <label>s to accomodate those containing linked <input>s
     'jsx-a11y/label-has-for': 0,
@@ -138,6 +153,9 @@ module.exports = {
 
         // prefer T[] style of arrays
         '@typescript-eslint/array-type': 2,
+
+        // prevent types from being redundantly specified in JSDoc comments
+        'jsdoc/no-types': 2,
       },
     },
   ],

--- a/index.js
+++ b/index.js
@@ -26,10 +26,8 @@ module.exports = {
     'jsdoc/require-hyphen-before-param-description': [2, 'never'],
     'jsdoc/require-description': 2,
     'jsdoc/require-description-complete-sentence': 2,
-    'jsdoc/require-param': 2,
     'jsdoc/require-param-description': 2,
     'jsdoc/require-param-name': 2,
-    'jsdoc/require-returns': 2,
     'jsdoc/require-returns-description': 2,
 
     // allow non-ID-linked <label>s to accomodate those containing linked <input>s

--- a/package-lock.json
+++ b/package-lock.json
@@ -1147,6 +1147,11 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
+    "comment-parser": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.6.2.tgz",
+      "integrity": "sha512-Wdms0Q8d4vvb2Yk72OwZjwNWtMklbC5Re7lD9cjCP/AG1fhocmc0TrxGBBAXPLy8fZQPrfHGgyygwI0lA7pbzA=="
+    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -1629,6 +1634,19 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
+      }
+    },
+    "eslint-plugin-jsdoc": {
+      "version": "15.12.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-15.12.0.tgz",
+      "integrity": "sha512-oP+rOqAf54QLbJM3ECqhg8VOrcMfqBSbGSYCWAVX8cy0ySWXK1Z7yg8QylY1bedrRBAvxyWBxdgzDP6Uy6WoTg==",
+      "requires": {
+        "comment-parser": "^0.6.2",
+        "debug": "^4.1.1",
+        "jsdoctypeparser": "^5.1.1",
+        "lodash": "^4.17.15",
+        "object.entries-ponyfill": "^1.0.1",
+        "regextras": "^0.6.1"
       }
     },
     "eslint-plugin-jsx-a11y": {
@@ -3706,6 +3724,11 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true
     },
+    "jsdoctypeparser": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-5.1.1.tgz",
+      "integrity": "sha512-APGygIJrT5bbz5lsVt8vyLJC0miEbQf/z9ZBfTr4RYvdia8AhWMRlYgivvwHG5zKD/VW3d6qpChCy64hpQET3A=="
+    },
     "jsdom": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
@@ -4252,6 +4275,11 @@
         "has": "^1.0.3"
       }
     },
+    "object.entries-ponyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object.entries-ponyfill/-/object.entries-ponyfill-1.0.1.tgz",
+      "integrity": "sha1-Kavfd8v70mVm3RqiTp2I9lQz0lY="
+    },
     "object.fromentries": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.1.tgz",
@@ -4645,6 +4673,11 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw=="
+    },
+    "regextras": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/regextras/-/regextras-0.6.1.tgz",
+      "integrity": "sha512-EzIHww9xV2Kpqx+corS/I7OBmf2rZ0pKKJPsw5Dc+l6Zq1TslDmtRIP9maVn3UH+72MIXmn8zzDgP07ihQogUA=="
     },
     "remove-trailing-separator": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "eslint-config-airbnb": "^18.0.1",
     "eslint-config-prettier": "^6.4.0",
     "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-jsdoc": "^15.12.0",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-prettier": "^3.1.1",
     "eslint-plugin-react": "^7.16.0",


### PR DESCRIPTION
This ensures that JSDoc comments, when they exist, are well-formatted. Specifically, that they have a sentence-form description, document their parameters and return value, and use reasonable indentation.

We could require a JSDoc comment on all functions/classes/methods by default, but we're far away from this at the moment so I'm not sure if it's a useful rule to enable. Projects can always enable it manually if they'd like to strive for this.